### PR TITLE
Colossalg - Only execute middleware when matching route is found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "php": "^8.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "colossal/colossal-http-message": "^2.0"
+        "colossal/colossal-http-message": "^2.0",
+        "colossal/colossal-middleware-queue": "^1.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4fa2e16c204792e657d3f0513eb96d02",
+    "content-hash": "0244fe45182d5e5cb11c680aad56c86f",
     "packages": [
         {
             "name": "colossal/colossal-http-message",
@@ -57,6 +57,58 @@
                 "source": "https://github.com/colossalg/Colossal-HTTP-Message/tree/v2.0.1"
             },
             "time": "2023-06-04T08:29:34+00:00"
+        },
+        {
+            "name": "colossal/colossal-middleware-queue",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/colossalg/Colossal-Middleware-Queue.git",
+                "reference": "742881766218b0d432dcfacd3ccad87a9b395b5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/colossalg/Colossal-Middleware-Queue/zipball/742881766218b0d432dcfacd3ccad87a9b395b5e",
+                "reference": "742881766218b0d432dcfacd3ccad87a9b395b5e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0",
+                "psr/http-server-handler": "^1.0",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.9",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Colossal\\MiddlewareQueue\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Angus Wylie",
+                    "homepage": "https://github.com/colossalg",
+                    "role": "developer"
+                }
+            ],
+            "description": "A PSR-15 middleware allowing multiple other PSR-15 middleware to be treated as a single entity.",
+            "homepage": "https://github.com/colossalg/Colossal-Middleware-Queue",
+            "keywords": [
+                "middleware",
+                "psr-15"
+            ],
+            "support": {
+                "issues": "https://github.com/colossalg/Colossal-Middleware-Queue/issues",
+                "source": "https://github.com/colossalg/Colossal-Middleware-Queue/tree/v1.0.1"
+            },
+            "time": "2023-11-05T06:48:04+00:00"
         },
         {
             "name": "psr/http-message",

--- a/src/Route.php
+++ b/src/Route.php
@@ -36,8 +36,25 @@ class Route implements RequestHandlerInterface
     {
         return (
             $this->method === $request->getMethod() &&
-            boolval(preg_match($this->pattern, Router::getServerRequestRoutingPath($request)))
+            boolval(preg_match($this->pattern, Router::getServerRequestRouteMatchPath($request)))
         );
+    }
+
+    /**
+     * Process a request.
+     *
+     * This will:
+     *      - Execute the middleware in the request's middleware queue.
+     *      - Execute the handler of this route.
+     *
+     * @param ServerRequestInterface $request The server request to process.
+     * @return ResponseInterface The response resulting from processing the request.
+     */
+    public function processRequest(ServerRequestInterface $request): ResponseInterface
+    {
+        $middlewareQueue = Router::getServerRequestMiddlewareQueue($request);
+
+        return $middlewareQueue->process($request, $this);
     }
 
     /**
@@ -47,7 +64,7 @@ class Route implements RequestHandlerInterface
     {
         // Parse the request params from the URI's path component.
 
-        $requestPath    = Router::getServerRequestRoutingPath($request);
+        $requestPath    = Router::getServerRequestRouteMatchPath($request);
         $requestParams  = [];
         if (
             !preg_match(

--- a/test/Dummy/DummyMiddleware.php
+++ b/test/Dummy/DummyMiddleware.php
@@ -16,26 +16,17 @@ use Psr\Http\Server\{
 class DummyMiddleware implements MiddlewareInterface
 {
     /**
-     * Constructor.
-     * @param string $name The name of this middleware.
-     */
-    public function __construct(string $name)
-    {
-        $this->name = $name;
-    }
-
-    /**
      * @see MiddlewareInterface::process()
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $request = $request->withAttribute($this->name, true);
+        $this->wasExecuted = true;
 
         return $handler->handle($request);
     }
 
     /**
-     * @var string The name of this middleware.
+     * @var bool Whether this middleware was executed.
      */
-    public string $name;
+    public bool $wasExecuted = false;
 }


### PR DESCRIPTION
The middleware should probably only be executed when a matching route is found rather than as the sub-routers are traversed during the search for a matching route.

This PR makes this change by:
 - Pushing the middleware of the traversed sub-routers on to a middleware queue stored as an attribute in the request.
 - Processing this middleware queue at the time of calling a matching route's handler.